### PR TITLE
[BI-1347] - Germplasm pedigree view

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ Use the following snippets (in order) to fully set up a tree.
       //OPTIONAL a function which returns a link to a germplasm information page, returning null will create a node without a link.
       function(germplasmDbId){ 
           return "https://brapi.myserver.org/germ/"+germplasmDbId+".html";
+      },
+      //OPTIONAL additional configuration options
+      {
+        credentials: 'same-site', //see https://developer.mozilla.org/en-US/docs/Web/API/Request/credentials for options
+        urlTarget: '_blank', //see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target for options
+        nodeNameFn: function(d) { // allows for customization of the name displayed on a pedigree node
+            return d.value.name;
+        },
+        textSize: "14",
+        textFont: "sans-serif",
+        arrowRight: function() { //resolve the right arrow display
+            return "&#xe092;";
+        },
+        arrowUp: function() { //resolve the up arrow display
+            return "&#xe093;";
+        },
+        arrowDown: function() { //resolve the down arrow display
+            return "&#xe094;";
+        },
       }
     );
     ```

--- a/main.js
+++ b/main.js
@@ -1,7 +1,7 @@
 
-    export default function PedigreeViewer(server,auth,version,urlFunc){
+    export default function PedigreeViewer(server,auth,version,urlFunc,credentials){
         var pdgv = {};
-        var brapijs = BrAPI(server,version,auth);
+        var brapijs = BrAPI(server,version,auth,undefined,credentials);
         var root = null;
         var access_token = null;
         var loaded_nodes = {};

--- a/main.js
+++ b/main.js
@@ -35,6 +35,7 @@
                     var parents = mothers.concat(fathers).filter(function(d, index, self){
                         return d!==undefined &&
                                d!==null &&
+                               d.trim().length > 0 &&
                                loaded_nodes[d]===undefined &&
                                self.indexOf(d) === index;
                     });

--- a/main.js
+++ b/main.js
@@ -1,7 +1,28 @@
 
-    export default function PedigreeViewer(server,auth,version,urlFunc,credentials){
+    export default function PedigreeViewer(server,auth,version,urlFunc,options){
+        const additionalOptions = Object.assign({}, {
+            credentials: 'same-site',
+            urlTarget: '_blank',
+            nodeNameFn: function(d) {
+                return d.value.name;
+            },
+            textSize: "14",
+            textFont: "sans-serif",
+            numAncestors: 1,
+            treeNodePadding:220,
+            treeLevelPadding:200,
+            arrowRight: function() {
+                return "&#xe092;";
+            },
+            arrowUp: function() {
+                return "&#xe093;";
+            },
+            arrowDown: function() {
+                return "&#xe094;";
+            },
+        }, options);
         var pdgv = {};
-        var brapijs = BrAPI(server,version,auth,undefined,credentials);
+        var brapijs = BrAPI(server,version,auth,undefined,additionalOptions.credentials);
         var root = null;
         var access_token = null;
         var loaded_nodes = {};
@@ -10,12 +31,12 @@
         var newTreeLoading = null;
         var load_markers = function(){return []};
         var marker_data = {};
-        var getTextSize = TextSizer("14","sans-serif");
+        var getTextSize = TextSizer(additionalOptions.textSize, additionalOptions.textFont);
         
-        var tree_node_padding_default = 220;
+        var tree_node_padding_default = additionalOptions.treeNodePadding;
         var tree_node_padding = tree_node_padding_default;
         
-        var tree_level_padding_default = 200;
+        var tree_level_padding_default = additionalOptions.treeLevelPadding;
         var tree_level_padding = tree_level_padding_default;
         
         urlFunc = urlFunc!=undefined?urlFunc:function(){return null};
@@ -25,7 +46,7 @@
             loaded_nodes = {};
             var all_nodes = [];
             var levels =0;
-            var number_ancestors =1;
+            var number_ancestors = additionalOptions.numAncestors;
             load_node_and_all_ancestors([stock_id]);
             function load_node_and_all_ancestors(ids){
                 load_nodes(ids, function(nodes){
@@ -317,7 +338,7 @@
               .attr("font-weight","bold")
               .attr('text-anchor',"middle")
               .attr('class', 'glyphicon')
-              .html("&#xe092;")
+              .html(additionalOptions.arrowRight())
               .attr('fill',"white");
             //create expander handles on nodes
             var expanders = nodeNodes.append('g').classed("expanders",true);
@@ -337,11 +358,11 @@
               .style("cursor","pointer")
               .attr('y',52)
               .attr('x',-0.5)
-              .attr("font-size","14px")
+              .attr("font-size",additionalOptions.textFont+"px")
               .attr("font-weight","bold")
               .attr('text-anchor',"middle")
               .attr('class', 'glyphicon')
-              .html("&#xe094;")
+              .html(additionalOptions.arrowDown())
               .attr('fill',"white");
             child_expander.on("click",function(d){
               d3.select(this).on('click',null);
@@ -369,11 +390,11 @@
               .style("cursor","pointer")
               .attr('y',-39)
               .attr('x',-0.5)
-              .attr("font-size","14px")
+              .attr("font-size",additionalOptions.textFont+"px")
               .attr("font-weight","bold")
               .attr('text-anchor',"middle")
               .attr('class', 'glyphicon')
-              .html("&#xe093;")
+              .html(additionalOptions.arrowUp())
               .attr('fill',"white");
             parent_expander.on("click",function(d){
               d3.select(this).on('click',null);
@@ -418,12 +439,12 @@
                 .attr('href',function(d){
                   return urlFunc(d.id);
                 })
-                .attr('target','_blank')
+                .attr('target',additionalOptions.urlTarget)
                 .append('text').classed('node-name-text',true)
                 .attr('y',15)
                 .attr('text-anchor',"middle")
                 .text(function(d){
-                  return d.value.name;
+                  return additionalOptions.nodeNameFn(d);
                 })
                 .attr('fill',"black");
               nodeNodes.filter(function(d){return d.url===undefined;})
@@ -431,7 +452,7 @@
                 .attr('y',15)
                 .attr('text-anchor',"middle")
                 .text(function(d){
-                  return d.value.name;
+                    return additionalOptions.nodeNameFn(d);
                 })
                 .attr('fill',"black");
             

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@solgenomics/brapi-pedigree-viewer",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Try it out [here](https://solgenomics.github.io/BrAPI-Pedigree-Viewer/)",
   "main": "build/PedigreeViewer.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
   },
   "homepage": "https://github.com/solgenomics/BrAPI-Pedigree-Viewer#readme",
   "dependencies": {
-    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#db619b03de55d05f9923ac0f19b57e0c0e9a60b9",
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
     "@solgenomics/d3-pedigree-tree": "git+https://github.com/solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c"
   },
   "devDependencies": {
     "@solgenomics/brapp-wrapper": "^1.1.0"
   },
   "peerDependencies": {
-    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#db619b03de55d05f9923ac0f19b57e0c0e9a60b9",
-    "d3": "7.4.4"
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
+    "d3": "^4.11.0"
   },
   "brapp": {
     "out": "example/index.html",

--- a/package.json
+++ b/package.json
@@ -19,13 +19,13 @@
   },
   "homepage": "https://github.com/solgenomics/BrAPI-Pedigree-Viewer#readme",
   "dependencies": {
-    "@solgenomics/d3-pedigree-tree": "^1.1.1"
+    "@solgenomics/d3-pedigree-tree": "github:solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c"
   },
   "devDependencies": {
     "@solgenomics/brapp-wrapper": "^1.1.0"
   },
   "peerDependencies": {
-    "@solgenomics/brapijs": "^0.3.6",
+    "@solgenomics/brapijs": "github:solgenomics/BrAPI-js#5802afad2874372a968960109bb2af5809cd58b8",
     "d3": "^4.11.0"
   },
   "brapp": {

--- a/package.json
+++ b/package.json
@@ -19,14 +19,14 @@
   },
   "homepage": "https://github.com/solgenomics/BrAPI-Pedigree-Viewer#readme",
   "dependencies": {
-    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#db619b03de55d05f9923ac0f19b57e0c0e9a60b9",
     "@solgenomics/d3-pedigree-tree": "git+https://github.com/solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c"
   },
   "devDependencies": {
     "@solgenomics/brapp-wrapper": "^1.1.0"
   },
   "peerDependencies": {
-    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#db619b03de55d05f9923ac0f19b57e0c0e9a60b9",
     "d3": "7.4.4"
   },
   "brapp": {

--- a/package.json
+++ b/package.json
@@ -19,15 +19,15 @@
   },
   "homepage": "https://github.com/solgenomics/BrAPI-Pedigree-Viewer#readme",
   "dependencies": {
-    "@solgenomics/d3-pedigree-tree": "github:solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c",
-    "@solgenomics/brapijs": "github:Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56"
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
+    "@solgenomics/d3-pedigree-tree": "git+https://github.com/solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c"
   },
   "devDependencies": {
     "@solgenomics/brapp-wrapper": "^1.1.0"
   },
   "peerDependencies": {
-    "@solgenomics/brapijs": "github:Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
-    "d3": "^4.11.0"
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
+    "d3": "7.4.4"
   },
   "brapp": {
     "out": "example/index.html",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@solgenomics/brapp-wrapper": "^1.1.0"
   },
   "peerDependencies": {
-    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
+    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#v2.0.2",
     "d3": "^4.11.0"
   },
   "brapp": {

--- a/package.json
+++ b/package.json
@@ -19,13 +19,14 @@
   },
   "homepage": "https://github.com/solgenomics/BrAPI-Pedigree-Viewer#readme",
   "dependencies": {
-    "@solgenomics/d3-pedigree-tree": "github:solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c"
+    "@solgenomics/d3-pedigree-tree": "github:solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c",
+    "@solgenomics/brapijs": "github:Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56"
   },
   "devDependencies": {
     "@solgenomics/brapp-wrapper": "^1.1.0"
   },
   "peerDependencies": {
-    "@solgenomics/brapijs": "github:solgenomics/BrAPI-js#5802afad2874372a968960109bb2af5809cd58b8",
+    "@solgenomics/brapijs": "github:Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
     "d3": "^4.11.0"
   },
   "brapp": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "homepage": "https://github.com/solgenomics/BrAPI-Pedigree-Viewer#readme",
   "dependencies": {
-    "@solgenomics/brapijs": "git+https://github.com/Breeding-Insight/BrAPI-js#b447b23dcf8ecbc14f5bce0e6547e92544e41e56",
     "@solgenomics/d3-pedigree-tree": "git+https://github.com/solgenomics/d3-pedigree-tree#f799b499c8019cfccd550d4297196e365c208d5c"
   },
   "devDependencies": {


### PR DESCRIPTION
# Description
**Story:** [BI-1347 -  Germplasm Pedigree View](https://breedinginsight.atlassian.net/browse/BI-1347)

Making the pedigree viewer more configurable.  This is primarily done through an `additionalOptions` object.

NOTE: Before merging this PR, the BrAPI-JS dependency needs to be updated to point to the merge commit of [Breeding-Insight/BrAPI-Pedigree-Viewer/BI-1347](https://github.com/Breeding-Insight/BrAPI-js/pull/1).

# Dependencies
[Breeding-Insight/BrAPI-Pedigree-Viewer/BI-1347](https://github.com/Breeding-Insight/BrAPI-js/pull/1)

# Testing
This is tested implicitly by testing BI-1347


# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation