### PR TITLE
[BI-1494] Improve Pedigree Viewer

### DIFF
--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@
             credentials: 'same-site',
             urlTarget: '_blank',
             nodeNameFn: function(d) {
-                return d.value.name;
+                return [d.value.name];
             },
             textSize: "14",
             textFont: "sans-serif",
@@ -12,6 +12,7 @@
             numAncestors: 1,
             treeNodePadding:220,
             treeLevelPadding:200,
+            nodeIconGap:30,
             arrowRight: function() {
                 return "&#xe092;";
             },
@@ -597,7 +598,7 @@
 
         function generateChildExpanders(layout, nodes, expanders) {
 
-            const iconGap = 30;
+            const iconGap = additionalOptions.nodeIconGap;
             const circleRadius = 10;
             const pointerSize = 20;
             const lineWidth = 4;
@@ -650,7 +651,7 @@
         }
 
         function generateParentExpanders(layout, expanders) {
-            const iconGap = 30;
+            const iconGap = additionalOptions.nodeIconGap;
             const circleRadius = 10;
             const pointerSize = 20;
             const lineWidth = 4;

--- a/main.js
+++ b/main.js
@@ -217,7 +217,6 @@
         }
         
         function drawTree(trans,draw_width,draw_height){
-            console.log("redraw");
             if(!myTree) return;
             var layout = myTree();
                         
@@ -298,7 +297,6 @@
             
             
             //set up draw layers
-            // TODO: Can we set up child selector layers in here?
             var linkLayer = content.select('.link-layer');
             if(linkLayer.empty()){
                 linkLayer = content.append('g').classed('link-layer',true);
@@ -350,7 +348,6 @@
             generateNodesHTML(root, nodeNodes, additionalOptions);
 
             //create expander handles on nodes
-            // TODO: Need to draw these before, but need the
             generateChildExpanders(layout, nodeNodes, expanders);
             generateParentExpanders(layout, expanders);
 
@@ -390,7 +387,6 @@
                 .attr("y",10);
             var allmks = newmks.merge(mks);
             allmks.attr("transform",(d,i)=>`translate(15,${i*25})`)
-            console.log(marker_data);
             allmks.select(".marker-bg").attr("width",d=>marker_data.__widths[0]);
             allmks.select("text")
                 .attr("x",d=>marker_data.__widths[0]/2)
@@ -480,7 +476,7 @@
                 const highlightWidth = nodeShapeWidth + (highlightThickness * 2);
 
                 // Node Highlight
-                nodes.append('rect').classed("node-name-highlight",true)
+                node.append('rect').classed("node-name-highlight",true)
                   .attr('fill',function(d){
                       return d.id==root?"pink":"none";
                   })
@@ -493,7 +489,7 @@
                   .attr("x",-(highlightWidth/2));
 
                 // Node shape
-                nodes.append('rect').classed("node-name-wrapper",true)
+                node.append('rect').classed("node-name-wrapper",true)
                   .attr('fill',"white")
                   .attr('stroke',"grey")
                   .attr('stroke-width',2)
@@ -640,9 +636,9 @@
                     d3.select(this).on('click',null);
                     var end_blink = load_blink(d3.select(this).select("circle").node());
                     var to_load = d.value.children.filter(Boolean).map(String);
-                    load_nodes(to_load,function(nodes){
+                    load_nodes(to_load,function(newNodes){
                         end_blink();
-                        layout.pdgtree.add(nodes);
+                        layout.pdgtree.add(newNodes);
                         drawTree(d3.transition().duration(transitionDuration));
                     });
                 });
@@ -686,9 +682,9 @@
                 d3.select(this).on('click',null);
                 var end_blink = load_blink(d3.select(this).select("circle").node());
                 var to_load = [d.value.mother_id,d.value.father_id].filter(Boolean).map(String);
-                load_nodes(to_load,function(nodes){
+                load_nodes(to_load,function(newNodes){
                     end_blink();
-                    layout.pdgtree.add(nodes);
+                    layout.pdgtree.add(newNodes);
                     drawTree(d3.transition().duration(transitionDuration));
                 });
             });


### PR DESCRIPTION
# Description
**Story:** [BI-1494 - Improve Pedigree View Display](https://breedinginsight.atlassian.net/browse/BI-1494)

AFTER MERGE:
- Tag with next version locally and push that tag up to github. This will allow us to reference it from biweb. 

Work done: 
- Added the option for multiline text in the node, but still supports single line text. 
  - Adjusting all of the spacing to account for the expanded node size. 
- Refactored the pedigree viewer code so it is easier to work with. 
- Added an option to customize font size. 
- Exposed treeLevelPadding and nodeIconGap parameters in the additionalOptions set in the PedigreeViewer call in GermplasmPedigreesView.vue in order to enable possible fiddling of vertical height of links between nodes due to the increase of node heigh to accommodate multiline text. As is the pedigree viewer on BI looks different than that of BreedBase, but is still readable, so parameter adjustment will likely be shaped by stakeholder feedback.. 

# Dependencies
[bi-web: feature/BI-1494](https://github.com/Breeding-Insight/bi-web/pull/248)

# Testing
see bi-web 

# Checklist:

- [X] I have performed a self-review of my own code
- [X] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to documentation
- [ ] I have run TAF: [_\<link to TAF run>_](https://github.com/Breeding-Insight/taf/actions/runs/2671696187)
