### PR TITLE
BI-1553 - Pedigree View on Firefox

### DIFF
--- a/main.js
+++ b/main.js
@@ -733,6 +733,9 @@
         var context = canvas.getContext('2d');
         return function (text) {
             context.font = fontSize + 'px ' + fontFace;
-            return context.measureText(text);
+            return {
+                'width': context.measureText(txt).width,
+                'height': parseInt(context.font)
+            };
         };
     }

--- a/main.js
+++ b/main.js
@@ -468,7 +468,7 @@
                 var maxWidth = 0;
                 textAsArray.forEach(function(line) {
                     const textSize = getTextSize(line);
-                    totalHeight += textSize.fontBoundingBoxAscent;
+                    totalHeight += textSize.actualBoundingBoxAscent + 5;
                     maxWidth = textSize.width > maxWidth ? textSize.width : maxWidth;
                 });
                 const nodeShapeHeight = totalHeight + (textMarginVertical * 2);
@@ -523,7 +523,7 @@
 
         function appendText(element, textAsArray) {
             for (const index in textAsArray) {
-                const textY = getTextSize(textAsArray[index]).fontBoundingBoxAscent * (parseInt(index) + 1);
+                const textY = (getTextSize(textAsArray[index]).actualBoundingBoxAscent + 5) * (parseInt(index) + 1);
                 element.append('text').classed('node-name-text',true)
                   .attr('y', textY)
                   .attr('text-anchor',"middle")
@@ -733,9 +733,8 @@
         var context = canvas.getContext('2d');
         return function (text) {
             context.font = fontSize + 'px ' + fontFace;
-            return {
-                'width': context.measureText(txt).width,
-                'height': parseInt(context.font)
-            };
+            let ret = context.measureText(text);
+            ret.height = parseInt(context.font);
+            return ret;
         };
     }


### PR DESCRIPTION
# Description
**Story:** https://breedinginsight.atlassian.net/browse/BI-1553

Updated various places in the code that are using the `TextMetrics.fontBoundingBoxAscent` to use `TextMetrics.actualBoundingBoxAscent` to have broader browser support (Firefox doesn't support `fontBoundingBoxAscent`)

AFTER MERGE:

Tag with next version locally and push that tag up to github. This will allow us to reference it from biweb.



# Dependencies

https://github.com/Breeding-Insight/bi-web/pull/262

# Testing

See testing in https://github.com/Breeding-Insight/bi-web/pull/262

# Checklist:

- [x] I have performed a self-review of my own code
- [x] I have tested my code and ensured it meets the acceptance criteria of the story
- [ ] I have create/modified unit tests to cover this change
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to documentation
